### PR TITLE
Update style-guide.rst

### DIFF
--- a/style-guide.rst
+++ b/style-guide.rst
@@ -230,7 +230,7 @@ Excepción::
 
     function singleLine() { spam(); }
 
-Inmediatamente antes de una coma, punto y coma:
+Inmediatamente después de una coma, punto y coma:
 
 Sí::
 


### PR DESCRIPTION
Anteriormente, la documentación decía que debíamos dejar un espacio en blanco 'inmediatamente ANTES de una coma, punto y coma', cuando debería ser 'inmediatamente DESPUÉS'